### PR TITLE
update regex to fit blob url

### DIFF
--- a/oldest.js
+++ b/oldest.js
@@ -9,4 +9,4 @@
       let url = `https://github.com/${repo}/commits/${branch}?after=${commitId}+${commitCount-10}`;
       window.location = url;
   })
-})(window.location.pathname.match(/\/([^\/]+\/[^\/]+)(?:\/(?:tree|commits)\/(.+))?/));
+})(window.location.pathname.match(/\/([^\/]+\/[^\/]+)(?:\/(?:tree|commits|blob)\/([^\/]+))?/));


### PR DESCRIPTION
Hi @bpceee,

When we execute the script from https://github.com/nvm-sh/nvm/blob/add_nvm_num_version_groups/nvm-exec branch reference is lost.

This PR should fix it.