### PR TITLE
Fix for including different branch names

### DIFF
--- a/oldest.js
+++ b/oldest.js
@@ -1,12 +1,19 @@
-(([_, repo, branch='master']) => {
+(([_, repo]) => {
+  const branchElement = document.querySelector("#branch-select-menu > summary > span.css-truncate-target");
+  const branch = branchElement ? branchElement.textContent : 'master';
   fetch(`https://github.com/${repo}/tree/${branch}`)
     .then(res => res.text())
     .then(res => {
-      let mainDocument = new DOMParser().parseFromString(res, 'text/html');
+      const mainDocument = new DOMParser().parseFromString(res, 'text/html');
       let commitCount = mainDocument.evaluate('//span[@class="d-none d-sm-inline"]//strong', mainDocument.body).iterateNext().innerText;
       commitCount = Number(commitCount.trim().replaceAll(',', ''));
-      let commitId = mainDocument.evaluate('//*[@class="f6 Link--secondary text-mono ml-2 d-none d-lg-inline"]', mainDocument.body).iterateNext().getAttribute("href").split('/').pop();
-      let url = `https://github.com/${repo}/commits/${branch}?after=${commitId}+${commitCount-10}`;
+      const commitId = mainDocument
+        .evaluate('//*[@class="f6 Link--secondary text-mono ml-2 d-none d-lg-inline"]', mainDocument.body)
+        .iterateNext()
+        .getAttribute("href")
+        .split('/')
+        .pop();
+      const url = `https://github.com/${repo}/commits/${branch}?after=${commitId}+${commitCount-10}`;
       window.location = url;
   })
 })(window.location.pathname.match(/\/([^\/]+\/[^\/]+)(?:\/(?:tree|commits|blob)\/([^\/]+))?/));


### PR DESCRIPTION
If navigated from a repo's homepage that has branch `main`, the bookmarklet does not find the correct branch to view the oldest commit history page since it falls back on `master`. This PR fixes that by getting the branch name directly from the document. So navigating from either the repo home or commit history page will be working correctly.

Also, it includes some code formatting and converting `let` to `const` for appropriate variables. Not critical but nice to have in my opinion.